### PR TITLE
refactor: Rename C++ header file extensions

### DIFF
--- a/msbuild/LibTromino.Test/LibTromino.Test.vcxproj
+++ b/msbuild/LibTromino.Test/LibTromino.Test.vcxproj
@@ -23,7 +23,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\test\libtromino\unittest_helper.h" />
+    <ClInclude Include="..\..\test\libtromino\unittest_helper.hpp" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>

--- a/msbuild/LibTromino.Test/LibTromino.Test.vcxproj.filters
+++ b/msbuild/LibTromino.Test/LibTromino.Test.vcxproj.filters
@@ -32,7 +32,7 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\test\libtromino\unittest_helper.h">
+    <ClInclude Include="..\..\test\libtromino\unittest_helper.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msbuild/LibTromino2d/LibTromino2d.vcxproj
+++ b/msbuild/LibTromino2d/LibTromino2d.vcxproj
@@ -90,12 +90,12 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\gfx2d\board.h" />
-    <ClInclude Include="..\..\src\gfx2d\step.h" />
-    <ClInclude Include="..\..\src\gfx2d\style.h" />
-    <ClInclude Include="..\..\src\gfx2d\tromino_gfx2d.h" />
-    <ClInclude Include="..\..\src\gfx2d\view_model.h" />
-    <ClInclude Include="..\..\src\gfx2d\window.h" />
+    <ClInclude Include="..\..\src\gfx2d\board.hpp" />
+    <ClInclude Include="..\..\src\gfx2d\step.hpp" />
+    <ClInclude Include="..\..\src\gfx2d\style.hpp" />
+    <ClInclude Include="..\..\src\gfx2d\tromino_gfx2d.hpp" />
+    <ClInclude Include="..\..\src\gfx2d\view_model.hpp" />
+    <ClInclude Include="..\..\src\gfx2d\window.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\gfx2d\tromino_gfx2d.cpp" />

--- a/msbuild/LibTromino2d/LibTromino2d.vcxproj.filters
+++ b/msbuild/LibTromino2d/LibTromino2d.vcxproj.filters
@@ -15,22 +15,22 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\gfx2d\board.h">
+    <ClInclude Include="..\..\src\gfx2d\board.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\gfx2d\step.h">
+    <ClInclude Include="..\..\src\gfx2d\step.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\gfx2d\style.h">
+    <ClInclude Include="..\..\src\gfx2d\style.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\gfx2d\tromino_gfx2d.h">
+    <ClInclude Include="..\..\src\gfx2d\tromino_gfx2d.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\gfx2d\view_model.h">
+    <ClInclude Include="..\..\src\gfx2d\view_model.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\gfx2d\window.h">
+    <ClInclude Include="..\..\src\gfx2d\window.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msbuild/Tromino2d/Tromino2d.vcxproj
+++ b/msbuild/Tromino2d/Tromino2d.vcxproj
@@ -86,11 +86,11 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\gui\callback.h" />
-    <ClInclude Include="..\..\src\gui\cli_models.h" />
-    <ClInclude Include="..\..\src\gui\cli_options.h" />
-    <ClInclude Include="..\..\src\gui\init.h" />
-    <ClInclude Include="..\..\src\gui\params.h" />
+    <ClInclude Include="..\..\src\gui\callback.hpp" />
+    <ClInclude Include="..\..\src\gui\cli_models.hpp" />
+    <ClInclude Include="..\..\src\gui\cli_options.hpp" />
+    <ClInclude Include="..\..\src\gui\init.hpp" />
+    <ClInclude Include="..\..\src\gui\params.hpp" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\src\gui\callback.cpp" />

--- a/msbuild/Tromino2d/Tromino2d.vcxproj.filters
+++ b/msbuild/Tromino2d/Tromino2d.vcxproj.filters
@@ -15,19 +15,19 @@
     </Filter>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\gui\callback.h">
+    <ClInclude Include="..\..\src\gui\callback.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\gui\cli_models.h">
+    <ClInclude Include="..\..\src\gui\cli_models.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\gui\cli_options.h">
+    <ClInclude Include="..\..\src\gui\cli_options.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\gui\init.h">
+    <ClInclude Include="..\..\src\gui\init.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\gui\params.h">
+    <ClInclude Include="..\..\src\gui\params.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/msbuild/TrominoPuzzle.Cli/TrominoPuzzle.Cli.vcxproj
+++ b/msbuild/TrominoPuzzle.Cli/TrominoPuzzle.Cli.vcxproj
@@ -112,12 +112,12 @@
     <ClCompile Include="..\..\src\cli\trmn_graph_windows.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\cli\cli_models.h" />
-    <ClInclude Include="..\..\src\cli\cli_options.h" />
-    <ClInclude Include="..\..\src\cli\init.h" />
-    <ClInclude Include="..\..\src\cli\trmn_graph.h" />
-    <ClInclude Include="..\..\src\cli\trmn_graph_vt.h" />
-    <ClInclude Include="..\..\src\cli\trmn_graph_windows.h" />
+    <ClInclude Include="..\..\src\cli\cli_models.hpp" />
+    <ClInclude Include="..\..\src\cli\cli_options.hpp" />
+    <ClInclude Include="..\..\src\cli\init.hpp" />
+    <ClInclude Include="..\..\src\cli\trmn_graph.hpp" />
+    <ClInclude Include="..\..\src\cli\trmn_graph_vt.hpp" />
+    <ClInclude Include="..\..\src\cli\trmn_graph_windows.hpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msbuild/TrominoPuzzle.Cli/TrominoPuzzle.Cli.vcxproj.filters
+++ b/msbuild/TrominoPuzzle.Cli/TrominoPuzzle.Cli.vcxproj.filters
@@ -32,22 +32,22 @@
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\src\cli\cli_models.h">
+    <ClInclude Include="..\..\src\cli\cli_models.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\cli\cli_options.h">
+    <ClInclude Include="..\..\src\cli\cli_options.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\cli\init.h">
+    <ClInclude Include="..\..\src\cli\init.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\cli\trmn_graph.h">
+    <ClInclude Include="..\..\src\cli\trmn_graph.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\cli\trmn_graph_windows.h">
+    <ClInclude Include="..\..\src\cli\trmn_graph_windows.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\src\cli\trmn_graph_vt.h">
+    <ClInclude Include="..\..\src\cli\trmn_graph_vt.hpp">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -30,16 +30,16 @@ include_HEADERS += validation/tromino_validation.h
 lib_LTLIBRARIES += libtromino-validation.la
 
 tromino_SOURCES = \
-	cli/cli_models.h \
+	cli/cli_models.hpp \
 	cli/cli_options.cpp \
-	cli/cli_options.h \
+	cli/cli_options.hpp \
 	cli/init.cpp \
-	cli/init.h \
+	cli/init.hpp \
 	cli/main.cpp \
-	cli/params.h \
-	cli/trmn_graph.h \
+	cli/params.hpp \
 	cli/trmn_graph_vt.cpp \
-	cli/trmn_graph_vt.h
+	cli/trmn_graph_vt.hpp \
+	cli/trmn_graph.hpp
 tromino_CPPFLAGS = \
 	-I$(top_srcdir)/src/libtromino \
 	-I$(top_srcdir)/src/validation
@@ -49,15 +49,15 @@ tromino_LDADD = \
 bin_PROGRAMS += tromino
 
 libtromino_gfx2d_la_SOURCES = \
-	gfx2d/board.h \
-	gfx2d/step.h \
-	gfx2d/style.h \
+	gfx2d/board.hpp \
+	gfx2d/step.hpp \
+	gfx2d/style.hpp \
 	gfx2d/tromino_gfx2d.cpp \
-	gfx2d/tromino_gfx2d.h \
+	gfx2d/tromino_gfx2d.hpp \
 	gfx2d/view_model.cpp \
-	gfx2d/view_model.h \
+	gfx2d/view_model.hpp \
 	gfx2d/window.cpp \
-	gfx2d/window.h
+	gfx2d/window.hpp
 libtromino_gfx2d_la_CPPFLAGS = \
 	-I/usr/include/SDL2 \
 	-I$(top_srcdir)/src/libtromino
@@ -67,23 +67,23 @@ libtromino_gfx2d_la_LDFLAGS = \
 	-version-info $(LIBTROMINO_CURRENT):$(LIBTROMINO_REVISION):$(LIBTROMINO_AGE)
 libtromino_gfx2d_la_LIBADD = libtromino.la
 include_HEADERS += \
-	gfx2d/board.h \
-	gfx2d/step.h \
-	gfx2d/tromino_gfx2d.h \
-	gfx2d/view_model.h \
-	gfx2d/window.h
+	gfx2d/board.hpp \
+	gfx2d/step.hpp \
+	gfx2d/tromino_gfx2d.hpp \
+	gfx2d/view_model.hpp \
+	gfx2d/window.hpp
 lib_LTLIBRARIES += libtromino-gfx2d.la
 
 tromino2d_SOURCES = \
 	gui/callback.cpp \
-	gui/callback.h \
-	gui/cli_models.h \
+	gui/callback.hpp \
+	gui/cli_models.hpp \
 	gui/cli_options.cpp \
-	gui/cli_options.h \
+	gui/cli_options.hpp \
 	gui/init.cpp \
-	gui/init.h \
+	gui/init.hpp \
 	gui/main.cpp \
-	gui/params.h
+	gui/params.hpp
 tromino2d_CPPFLAGS = \
 	-I/usr/include/SDL2 \
 	-I$(top_srcdir)/src/libtromino \

--- a/src/cli/cli_models.hpp
+++ b/src/cli/cli_models.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef CLI_MODELS_H
-#define CLI_MODELS_H
+#ifndef CLI_MODELS_HPP
+#define CLI_MODELS_HPP
 
 namespace tromino::cli {
 
@@ -28,4 +28,4 @@ struct options {
 
 } // namespace tromino::cli
 
-#endif // CLI_MODELS_H
+#endif // CLI_MODELS_HPP

--- a/src/cli/cli_options.cpp
+++ b/src/cli/cli_options.cpp
@@ -4,11 +4,11 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "cli_options.h"
+#include "cli_options.hpp"
 
 #include <iostream>
 
-#include "params.h"
+#include "params.hpp"
 
 namespace tromino::cli {
 

--- a/src/cli/cli_options.hpp
+++ b/src/cli/cli_options.hpp
@@ -4,15 +4,15 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GUI_CLI_OPTIONS_H
-#define GUI_CLI_OPTIONS_H
+#ifndef CLI_OPTIONS_HPP
+#define CLI_OPTIONS_HPP
 
-#include "cli_models.h"
+#include "cli_models.hpp"
 
 #include <iostream>
 #include <string>
 
-namespace tromino::tromino2d {
+namespace tromino::cli {
 
 void print_usage(std::ostream& os) noexcept;
 
@@ -20,6 +20,6 @@ bool read_options(
     int const argc, char const* const argv[], options& options,
     std::string& error) noexcept;
 
-} // namespace tromino::tromino2d
+} // namespace tromino::cli
 
-#endif // GUI_CLI_OPTIONS_H
+#endif // CLI_OPTIONS_HPP

--- a/src/cli/init.cpp
+++ b/src/cli/init.cpp
@@ -4,16 +4,16 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "init.h"
+#include "init.hpp"
 
 #include <cstddef>
 #include <memory>
 
-#include "trmn_graph.h"
-#include "trmn_graph_vt.h"
+#include "trmn_graph.hpp"
+#include "trmn_graph_vt.hpp"
 
 #ifdef _WINDOWS
-#include "trmn_graph_windows.h"
+#include "trmn_graph_windows.hpp"
 #endif // _WINDOWS
 
 namespace tromino::cli::app {

--- a/src/cli/init.hpp
+++ b/src/cli/init.hpp
@@ -4,10 +4,10 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef CLI_INIT_H
-#define CLI_INIT_H
+#ifndef CLI_INIT_HPP
+#define CLI_INIT_HPP
 
-#include "cli_models.h"
+#include "cli_models.hpp"
 
 namespace tromino::cli::app {
 
@@ -21,4 +21,4 @@ void init(
 
 } // namespace tromino::cli::app
 
-#endif // CLI_INIT_H
+#endif // CLI_INIT_HPP

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -9,9 +9,9 @@
 
 #include "tromino_validation.h"
 
-#include "cli_models.h"
-#include "cli_options.h"
-#include "init.h"
+#include "cli_models.hpp"
+#include "cli_options.hpp"
+#include "init.hpp"
 
 int main(int const argc, char const* const argv[]) noexcept {
     tromino::cli::options options;

--- a/src/cli/params.hpp
+++ b/src/cli/params.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef CLI_PARAMS_H
-#define CLI_PARAMS_H
+#ifndef CLI_PARAMS_HPP
+#define CLI_PARAMS_HPP
 
 namespace tromino::cli::params {
 
@@ -21,4 +21,4 @@ constexpr int const USE_WCH_ARG_IDX{4};
 
 } // namespace tromino::cli::params
 
-#endif // CLI_PARAMS_H
+#endif // CLI_PARAMS_HPP

--- a/src/cli/trmn_graph.hpp
+++ b/src/cli/trmn_graph.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef CLI_TRMN_GRAPH_H
-#define CLI_TRMN_GRAPH_H
+#ifndef CLI_TRMN_GRAPH_HPP
+#define CLI_TRMN_GRAPH_HPP
 
 #ifdef _WINDOWS
 #define WIN32_LEAN_AND_MEAN
@@ -88,4 +88,4 @@ get_sprite(int const flip_x, int const flip_y) noexcept {
 
 } // namespace tromino::cli
 
-#endif // CLI_TRMN_GRAPH_H
+#endif // CLI_TRMN_GRAPH_HPP

--- a/src/cli/trmn_graph_vt.cpp
+++ b/src/cli/trmn_graph_vt.cpp
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "trmn_graph_vt.h"
+#include "trmn_graph_vt.hpp"
 
 #include <array>
 #include <cassert>

--- a/src/cli/trmn_graph_vt.hpp
+++ b/src/cli/trmn_graph_vt.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef CLI_TRMN_GRAPH_VT_H
-#define CLI_TRMN_GRAPH_VT_H
+#ifndef CLI_TRMN_GRAPH_VT_HPP
+#define CLI_TRMN_GRAPH_VT_HPP
 
 #ifdef _WINDOWS
 #define WIN32_LEAN_AND_MEAN
@@ -17,7 +17,7 @@
 
 #include "tromino.h"
 
-#include "trmn_graph.h"
+#include "trmn_graph.hpp"
 
 namespace tromino::cli::vt {
 
@@ -71,4 +71,4 @@ void use_vt(board_t& tromino_board, std::ostream& os) noexcept;
 
 } // namespace tromino::cli::vt
 
-#endif // CLI_TRMN_GRAPH_VT_H
+#endif // CLI_TRMN_GRAPH_VT_HPP

--- a/src/cli/trmn_graph_windows.cpp
+++ b/src/cli/trmn_graph_windows.cpp
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "trmn_graph_windows.h"
+#include "trmn_graph_windows.hpp"
 
 #include <array>
 #include <cassert>

--- a/src/cli/trmn_graph_windows.hpp
+++ b/src/cli/trmn_graph_windows.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef CLI_TRMN_GRAPH_WINDOWS_H
-#define CLI_TRMN_GRAPH_WINDOWS_H
+#ifndef CLI_TRMN_GRAPH_WINDOWS_HPP
+#define CLI_TRMN_GRAPH_WINDOWS_HPP
 
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -14,7 +14,7 @@
 
 #include "tromino.h"
 
-#include "trmn_graph.h"
+#include "trmn_graph.hpp"
 
 namespace tromino::cli::windows {
 
@@ -46,4 +46,4 @@ void use_wch(board_t& tromino_board, std::ostream& os) noexcept;
 
 } // namespace tromino::cli::windows
 
-#endif // CLI_TRMN_GRAPH_WINDOWS_H
+#endif // CLI_TRMN_GRAPH_WINDOWS_HPP

--- a/src/gfx2d/board.hpp
+++ b/src/gfx2d/board.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GFX2D_BOARD_H
-#define GFX2D_BOARD_H
+#ifndef GFX2D_BOARD_HPP
+#define GFX2D_BOARD_HPP
 
 #include <cstddef>
 
@@ -22,4 +22,4 @@ struct Board {
 
 } // namespace tromino::gfx2d
 
-#endif // GFX2D_BOARD_H
+#endif // GFX2D_BOARD_HPP

--- a/src/gfx2d/step.hpp
+++ b/src/gfx2d/step.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GFX2D_STEP_H
-#define GFX2D_STEP_H
+#ifndef GFX2D_STEP_HPP
+#define GFX2D_STEP_HPP
 
 #include "tromino.h"
 
@@ -34,4 +34,4 @@ struct Step final {
 
 } // namespace tromino::gfx2d
 
-#endif // GFX2D_STEP_H
+#endif // GFX2D_STEP_HPP

--- a/src/gfx2d/style.hpp
+++ b/src/gfx2d/style.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GFX2D_STYLE_H
-#define GFX2D_STYLE_H
+#ifndef GFX2D_STYLE_HPP
+#define GFX2D_STYLE_HPP
 
 #include <SDL2/SDL.h>
 
@@ -21,4 +21,4 @@ struct Style {
 
 } // namespace tromino::gfx2d
 
-#endif // GFX2D_STYLE_H
+#endif // GFX2D_STYLE_HPP

--- a/src/gfx2d/tromino_gfx2d.cpp
+++ b/src/gfx2d/tromino_gfx2d.cpp
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "tromino_gfx2d.h"
+#include "tromino_gfx2d.hpp"
 
 #include <cassert>
 

--- a/src/gfx2d/tromino_gfx2d.hpp
+++ b/src/gfx2d/tromino_gfx2d.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GFX2D_TROMINO_GFX2D_H
-#define GFX2D_TROMINO_GFX2D_H
+#ifndef GFX2D_TROMINO_GFX2D_HPP
+#define GFX2D_TROMINO_GFX2D_HPP
 
 #include <SDL2/SDL.h>
 
@@ -38,4 +38,4 @@ void DrawTrominoOutline(
 
 } // namespace tromino::gfx2d
 
-#endif // GFX2D_TROMINO_GFX2D_H
+#endif // GFX2D_TROMINO_GFX2D_HPP

--- a/src/gfx2d/view_model.cpp
+++ b/src/gfx2d/view_model.cpp
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "view_model.h"
+#include "view_model.hpp"
 
 #include <cassert>
 

--- a/src/gfx2d/view_model.hpp
+++ b/src/gfx2d/view_model.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GFX2D_VIEW_MODEL_H
-#define GFX2D_VIEW_MODEL_H
+#ifndef GFX2D_VIEW_MODEL_HPP
+#define GFX2D_VIEW_MODEL_HPP
 
 #include <SDL2/SDL.h>
 
@@ -13,10 +13,10 @@
 #include <memory>
 #include <vector>
 
-#include "board.h"
-#include "step.h"
-#include "style.h"
-#include "tromino_gfx2d.h"
+#include "board.hpp"
+#include "step.hpp"
+#include "style.hpp"
+#include "tromino_gfx2d.hpp"
 
 namespace tromino::gfx2d {
 
@@ -72,4 +72,4 @@ get_flip(int const flip_x, int const flip_y) noexcept {
 
 } // namespace tromino::gfx2d
 
-#endif // GFX2D_VIEW_MODEL_H
+#endif // GFX2D_VIEW_MODEL_HPP

--- a/src/gfx2d/window.cpp
+++ b/src/gfx2d/window.cpp
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "window.h"
+#include "window.hpp"
 
 namespace tromino::gfx2d {
 

--- a/src/gfx2d/window.hpp
+++ b/src/gfx2d/window.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GFX2D_WINDOW_H
-#define GFX2D_WINDOW_H
+#ifndef GFX2D_WINDOW_HPP
+#define GFX2D_WINDOW_HPP
 
 #include <SDL2/SDL.h>
 
@@ -30,4 +30,4 @@ private:
 
 } // namespace tromino::gfx2d
 
-#endif // GFX2D_WINDOW_H
+#endif // GFX2D_WINDOW_HPP

--- a/src/gui/callback.cpp
+++ b/src/gui/callback.cpp
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "callback.h"
+#include "callback.hpp"
 
 struct SharedState;
 

--- a/src/gui/callback.hpp
+++ b/src/gui/callback.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GUI_CALLBACK_H
-#define GUI_CALLBACK_H
+#ifndef GUI_CALLBACK_HPP
+#define GUI_CALLBACK_HPP
 
 template <typename T>
 using tromino_cb_t = void (*)(
@@ -21,4 +21,4 @@ extern "C" void solve_puzzle_cb(
     int const pos_x, int const pos_y, int const flip_x, int const flip_y,
     void* const state) noexcept;
 
-#endif // GUI_CALLBACK_H
+#endif // GUI_CALLBACK_HPP

--- a/src/gui/cli_models.hpp
+++ b/src/gui/cli_models.hpp
@@ -4,19 +4,18 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GUI_INIT_H
-#define GUI_INIT_H
-
-#include <string>
-
-#include "board.h"
+#ifndef GUI_CLI_MODELS_HPP
+#define GUI_CLI_MODELS_HPP
 
 namespace tromino::tromino2d {
 
-int init(
-    tromino::gfx2d::Board const& board, int const width,
-    std::string const& title) noexcept;
+struct options {
+    int order{};
+    int x{};
+    int y{};
+    bool force{};
+};
 
 } // namespace tromino::tromino2d
 
-#endif // GUI_INIT_H
+#endif // GUI_CLI_MODELS_HPP

--- a/src/gui/cli_options.cpp
+++ b/src/gui/cli_options.cpp
@@ -4,9 +4,9 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "cli_options.h"
+#include "cli_options.hpp"
 
-#include "params.h"
+#include "params.hpp"
 
 namespace tromino::tromino2d {
 

--- a/src/gui/cli_options.hpp
+++ b/src/gui/cli_options.hpp
@@ -4,15 +4,15 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef CLI_OPTIONS_H
-#define CLI_OPTIONS_H
+#ifndef GUI_CLI_OPTIONS_HPP
+#define GUI_CLI_OPTIONS_HPP
 
-#include "cli_models.h"
+#include "cli_models.hpp"
 
 #include <iostream>
 #include <string>
 
-namespace tromino::cli {
+namespace tromino::tromino2d {
 
 void print_usage(std::ostream& os) noexcept;
 
@@ -20,6 +20,6 @@ bool read_options(
     int const argc, char const* const argv[], options& options,
     std::string& error) noexcept;
 
-} // namespace tromino::cli
+} // namespace tromino::tromino2d
 
-#endif // CLI_OPTIONS_H
+#endif // GUI_CLI_OPTIONS_HPP

--- a/src/gui/init.cpp
+++ b/src/gui/init.cpp
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "init.h"
+#include "init.hpp"
 
 #include <SDL2/SDL.h>
 
@@ -18,12 +18,12 @@
 #include <thread>
 #include <vector>
 
-#include "board.h"
-#include "callback.h"
-#include "step.h"
-#include "tromino_gfx2d.h"
-#include "view_model.h"
-#include "window.h"
+#include "board.hpp"
+#include "callback.hpp"
+#include "step.hpp"
+#include "tromino_gfx2d.hpp"
+#include "view_model.hpp"
+#include "window.hpp"
 
 namespace tromino::tromino2d {
 

--- a/src/gui/init.hpp
+++ b/src/gui/init.hpp
@@ -4,18 +4,19 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GUI_CLI_MODELS_H
-#define GUI_CLI_MODELS_H
+#ifndef GUI_INIT_HPP
+#define GUI_INIT_HPP
+
+#include <string>
+
+#include "board.hpp"
 
 namespace tromino::tromino2d {
 
-struct options {
-    int order{};
-    int x{};
-    int y{};
-    bool force{};
-};
+int init(
+    tromino::gfx2d::Board const& board, int const width,
+    std::string const& title) noexcept;
 
 } // namespace tromino::tromino2d
 
-#endif // GUI_CLI_MODELS_H
+#endif // GUI_INIT_HPP

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -11,12 +11,12 @@
 
 #include "tromino_validation.h"
 
-#include "board.h"
+#include "board.hpp"
 
-#include "cli_models.h"
-#include "cli_options.h"
-#include "init.h"
-#include "params.h"
+#include "cli_models.hpp"
+#include "cli_options.hpp"
+#include "init.hpp"
+#include "params.hpp"
 
 int main(int const argc, char const* const argv[]) noexcept {
     using namespace std::string_literals;

--- a/src/gui/params.hpp
+++ b/src/gui/params.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef GUI_PARAMS_H
-#define GUI_PARAMS_H
+#ifndef GUI_PARAMS_HPP
+#define GUI_PARAMS_HPP
 
 namespace tromino::tromino2d::params {
 
@@ -30,4 +30,4 @@ constexpr int const FORCE_ARG_IDX{4};
 
 } // namespace tromino::tromino2d::params
 
-#endif // GUI_PARAMS_H
+#endif // GUI_PARAMS_HPP

--- a/src/wasm/trmn/trmn.cpp
+++ b/src/wasm/trmn/trmn.cpp
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "trmn.h"
+#include "trmn.hpp"
 
 #include <SDL2/SDL.h>
 
@@ -14,11 +14,11 @@
 
 #include "tromino.h"
 
-#include "board.h"
-#include "step.h"
-#include "tromino_gfx2d.h"
-#include "view_model.h"
-#include "window.h"
+#include "board.hpp"
+#include "step.hpp"
+#include "tromino_gfx2d.hpp"
+#include "view_model.hpp"
+#include "window.hpp"
 
 namespace {
 

--- a/src/wasm/trmn/trmn.hpp
+++ b/src/wasm/trmn/trmn.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef WASM_TRMN_TRMN_H
-#define WASM_TRMN_TRMN_H
+#ifndef WASM_TRMN_TRMN_HPP
+#define WASM_TRMN_TRMN_HPP
 
 #include <emscripten.h>
 
@@ -13,4 +13,4 @@ EMSCRIPTEN_KEEPALIVE extern "C" void playTromino(
     int const order, int const markX, int const markY,
     int const width) noexcept;
 
-#endif // WASM_TRMN_TRMN_H
+#endif // WASM_TRMN_TRMN_HPP

--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -19,7 +19,7 @@ libtromino_test_SOURCES = \
 	libtromino/tromino_4x4_unittest.cpp \
 	libtromino/tromino_64x64_unittest.cpp \
 	libtromino/unittest_helper.cpp \
-	libtromino/unittest_helper.h \
+	libtromino/unittest_helper.hpp \
 	validation/tromino_validation_unittest.cpp
 
 libtromino_test_CPPFLAGS = \

--- a/test/libtromino/tromino_2x2_unittest.cpp
+++ b/test/libtromino/tromino_2x2_unittest.cpp
@@ -12,7 +12,7 @@
 
 #include "tromino.h"
 
-#include "unittest_helper.h"
+#include "unittest_helper.hpp"
 
 BOOST_AUTO_TEST_SUITE(tromino_2x2_test_suite)
 

--- a/test/libtromino/tromino_4x4_unittest.cpp
+++ b/test/libtromino/tromino_4x4_unittest.cpp
@@ -12,7 +12,7 @@
 
 #include "tromino.h"
 
-#include "unittest_helper.h"
+#include "unittest_helper.hpp"
 
 BOOST_AUTO_TEST_SUITE(tromino_4x4_test_suite)
 

--- a/test/libtromino/tromino_64x64_unittest.cpp
+++ b/test/libtromino/tromino_64x64_unittest.cpp
@@ -12,7 +12,7 @@
 
 #include "tromino.h"
 
-#include "unittest_helper.h"
+#include "unittest_helper.hpp"
 
 namespace {
 

--- a/test/libtromino/unittest_helper.cpp
+++ b/test/libtromino/unittest_helper.cpp
@@ -4,7 +4,7 @@
 
 // SPDX-License-Identifier: MIT
 
-#include "unittest_helper.h"
+#include "unittest_helper.hpp"
 
 void shim_add_tromino(
     int const pos_x, int const pos_y, int const flip_x, int const flip_y,

--- a/test/libtromino/unittest_helper.hpp
+++ b/test/libtromino/unittest_helper.hpp
@@ -4,8 +4,8 @@
 
 // SPDX-License-Identifier: MIT
 
-#ifndef TEST_LIBTROMINO_UNITTEST_HELPER_H
-#define TEST_LIBTROMINO_UNITTEST_HELPER_H
+#ifndef TEST_LIBTROMINO_UNITTEST_HELPER_HPP
+#define TEST_LIBTROMINO_UNITTEST_HELPER_HPP
 
 #include <iostream>
 #include <vector>
@@ -54,4 +54,4 @@ void shim_add_tromino(
 
 void print_shim_step_vector(std::vector<ShimStep> const& steps) noexcept;
 
-#endif // TEST_LIBTROMINO_UNITTEST_HELPER_H
+#endif // TEST_LIBTROMINO_UNITTEST_HELPER_HPP

--- a/xcode/LibTromino/LibTromino.xcodeproj/project.pbxproj
+++ b/xcode/LibTromino/LibTromino.xcodeproj/project.pbxproj
@@ -12,7 +12,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		7503E76826C88C490018B1F2 /* tromino.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tromino.h; sourceTree = "<group>"; };
+		7503E76826C88C490018B1F2 /* tromino.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = tromino.h; sourceTree = "<group>"; };
 		7503E76A26C88C490018B1F2 /* tromino.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; path = tromino.c; sourceTree = "<group>"; };
 		755F9D1F2811C878004C54E0 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		7594DBEE26C482A500CF433E /* libtromino.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libtromino.a; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/xcode/LibTromino2d/LibTromino2d.xcodeproj/project.pbxproj
+++ b/xcode/LibTromino2d/LibTromino2d.xcodeproj/project.pbxproj
@@ -7,28 +7,28 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		7503E7DB26C896C90018B1F2 /* tromino_gfx2d.h in Headers */ = {isa = PBXBuildFile; fileRef = 7503E7D926C896C90018B1F2 /* tromino_gfx2d.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7503E7DB26C896C90018B1F2 /* tromino_gfx2d.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 7503E7D926C896C90018B1F2 /* tromino_gfx2d.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		7503E7DC26C896C90018B1F2 /* tromino_gfx2d.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7503E7DA26C896C90018B1F2 /* tromino_gfx2d.cpp */; };
 		750984C326E44E83005B6E82 /* window.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 750984C126E44E83005B6E82 /* window.cpp */; };
-		750984C426E44E83005B6E82 /* window.h in Headers */ = {isa = PBXBuildFile; fileRef = 750984C226E44E83005B6E82 /* window.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		750984C426E44E83005B6E82 /* window.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 750984C226E44E83005B6E82 /* window.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 		750984C726E45054005B6E82 /* view_model.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 750984C526E45054005B6E82 /* view_model.cpp */; };
-		750984C826E45054005B6E82 /* view_model.h in Headers */ = {isa = PBXBuildFile; fileRef = 750984C626E45054005B6E82 /* view_model.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		750984CC26E45076005B6E82 /* style.h in Headers */ = {isa = PBXBuildFile; fileRef = 750984CA26E45076005B6E82 /* style.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		750984D026E455FE005B6E82 /* board.h in Headers */ = {isa = PBXBuildFile; fileRef = 750984CE26E455FE005B6E82 /* board.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		750984D426E55220005B6E82 /* step.h in Headers */ = {isa = PBXBuildFile; fileRef = 750984D226E55220005B6E82 /* step.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		750984C826E45054005B6E82 /* view_model.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 750984C626E45054005B6E82 /* view_model.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		750984CC26E45076005B6E82 /* style.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 750984CA26E45076005B6E82 /* style.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		750984D026E455FE005B6E82 /* board.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 750984CE26E455FE005B6E82 /* board.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
+		750984D426E55220005B6E82 /* step.hpp in Headers */ = {isa = PBXBuildFile; fileRef = 750984D226E55220005B6E82 /* step.hpp */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		7503E7B426C891FF0018B1F2 /* libtromino2d.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libtromino2d.a; sourceTree = BUILT_PRODUCTS_DIR; };
-		7503E7D926C896C90018B1F2 /* tromino_gfx2d.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = tromino_gfx2d.h; sourceTree = "<group>"; };
+		7503E7D926C896C90018B1F2 /* tromino_gfx2d.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = tromino_gfx2d.hpp; sourceTree = "<group>"; };
 		7503E7DA26C896C90018B1F2 /* tromino_gfx2d.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tromino_gfx2d.cpp; sourceTree = "<group>"; };
 		750984C126E44E83005B6E82 /* window.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = window.cpp; sourceTree = "<group>"; };
-		750984C226E44E83005B6E82 /* window.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = window.h; sourceTree = "<group>"; };
+		750984C226E44E83005B6E82 /* window.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.hpp; path = window.hpp; sourceTree = "<group>"; };
 		750984C526E45054005B6E82 /* view_model.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = view_model.cpp; sourceTree = "<group>"; };
-		750984C626E45054005B6E82 /* view_model.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = view_model.h; sourceTree = "<group>"; };
-		750984CA26E45076005B6E82 /* style.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = style.h; sourceTree = "<group>"; };
-		750984CE26E455FE005B6E82 /* board.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = board.h; sourceTree = "<group>"; };
-		750984D226E55220005B6E82 /* step.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = step.h; sourceTree = "<group>"; };
+		750984C626E45054005B6E82 /* view_model.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.hpp; path = view_model.hpp; sourceTree = "<group>"; };
+		750984CA26E45076005B6E82 /* style.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.hpp; path = style.hpp; sourceTree = "<group>"; };
+		750984CE26E455FE005B6E82 /* board.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.hpp; path = board.hpp; sourceTree = "<group>"; };
+		750984D226E55220005B6E82 /* step.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.hpp; path = step.hpp; sourceTree = "<group>"; };
 		755F9D222811CAF8004C54E0 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -64,15 +64,15 @@
 		7503E7D826C896C90018B1F2 /* gfx2d */ = {
 			isa = PBXGroup;
 			children = (
-				750984CE26E455FE005B6E82 /* board.h */,
-				750984D226E55220005B6E82 /* step.h */,
-				750984CA26E45076005B6E82 /* style.h */,
+				750984CE26E455FE005B6E82 /* board.hpp */,
+				750984D226E55220005B6E82 /* step.hpp */,
+				750984CA26E45076005B6E82 /* style.hpp */,
 				7503E7DA26C896C90018B1F2 /* tromino_gfx2d.cpp */,
-				7503E7D926C896C90018B1F2 /* tromino_gfx2d.h */,
+				7503E7D926C896C90018B1F2 /* tromino_gfx2d.hpp */,
 				750984C526E45054005B6E82 /* view_model.cpp */,
-				750984C626E45054005B6E82 /* view_model.h */,
+				750984C626E45054005B6E82 /* view_model.hpp */,
 				750984C126E44E83005B6E82 /* window.cpp */,
-				750984C226E44E83005B6E82 /* window.h */,
+				750984C226E44E83005B6E82 /* window.hpp */,
 			);
 			name = gfx2d;
 			path = ../../src/gfx2d;
@@ -92,12 +92,12 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				750984D026E455FE005B6E82 /* board.h in Headers */,
-				750984D426E55220005B6E82 /* step.h in Headers */,
-				750984CC26E45076005B6E82 /* style.h in Headers */,
-				7503E7DB26C896C90018B1F2 /* tromino_gfx2d.h in Headers */,
-				750984C826E45054005B6E82 /* view_model.h in Headers */,
-				750984C426E44E83005B6E82 /* window.h in Headers */,
+				750984D026E455FE005B6E82 /* board.hpp in Headers */,
+				750984D426E55220005B6E82 /* step.hpp in Headers */,
+				750984CC26E45076005B6E82 /* style.hpp in Headers */,
+				7503E7DB26C896C90018B1F2 /* tromino_gfx2d.hpp in Headers */,
+				750984C826E45054005B6E82 /* view_model.hpp in Headers */,
+				750984C426E44E83005B6E82 /* window.hpp in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/xcode/Tromino2d/Tromino2d.xcodeproj/project.pbxproj
+++ b/xcode/Tromino2d/Tromino2d.xcodeproj/project.pbxproj
@@ -32,21 +32,21 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		75002AC327A684E800CBB593 /* cli_models.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cli_models.h; sourceTree = "<group>"; };
+		75002AC327A684E800CBB593 /* cli_models.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = cli_models.hpp; sourceTree = "<group>"; };
 		75002AC427A684E900CBB593 /* cli_options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cli_options.cpp; sourceTree = "<group>"; };
-		75002AC627A684E900CBB593 /* cli_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cli_options.h; sourceTree = "<group>"; };
+		75002AC627A684E900CBB593 /* cli_options.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = cli_options.hpp; sourceTree = "<group>"; };
 		7503E7C426C892630018B1F2 /* tromino2d */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tromino2d; sourceTree = BUILT_PRODUCTS_DIR; };
 		752A62C4276FE49F0076CB0C /* init.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = init.cpp; sourceTree = "<group>"; };
-		752A62C6276FE49F0076CB0C /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		752A62C6276FE49F0076CB0C /* init.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = init.hpp; sourceTree = "<group>"; };
 		7530DEC5280212E800812ABF /* libSDL2-2.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libSDL2-2.0.dylib"; path = "$(BUILD_DIR)/libSDL2/libSDL2-2.0.dylib"; sourceTree = "<group>"; };
 		755F9D242811CB67004C54E0 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		758EF491284E51C00069A198 /* libtromino2d.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libtromino2d.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		758EF497284E535C0069A198 /* libtromino.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libtromino.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		758EF499284E535C0069A198 /* libtromino-validation.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libtromino-validation.a"; sourceTree = BUILT_PRODUCTS_DIR; };
-		759EB4162A3267F0000A1BAC /* callback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = callback.h; sourceTree = "<group>"; };
+		759EB4162A3267F0000A1BAC /* callback.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = callback.hpp; sourceTree = "<group>"; };
 		759EB4172A3267F0000A1BAC /* callback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = callback.cpp; sourceTree = "<group>"; };
 		75ACD98A26DAF724003E33CA /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
-		75E2E8B927FCAC0800B0525E /* params.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = params.h; sourceTree = "<group>"; };
+		75E2E8B927FCAC0800B0525E /* params.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.hpp; path = params.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,14 +97,14 @@
 			isa = PBXGroup;
 			children = (
 				759EB4172A3267F0000A1BAC /* callback.cpp */,
-				759EB4162A3267F0000A1BAC /* callback.h */,
-				75002AC327A684E800CBB593 /* cli_models.h */,
+				759EB4162A3267F0000A1BAC /* callback.hpp */,
+				75002AC327A684E800CBB593 /* cli_models.hpp */,
 				75002AC427A684E900CBB593 /* cli_options.cpp */,
-				75002AC627A684E900CBB593 /* cli_options.h */,
+				75002AC627A684E900CBB593 /* cli_options.hpp */,
 				752A62C4276FE49F0076CB0C /* init.cpp */,
-				752A62C6276FE49F0076CB0C /* init.h */,
+				752A62C6276FE49F0076CB0C /* init.hpp */,
 				75ACD98A26DAF724003E33CA /* main.cpp */,
-				75E2E8B927FCAC0800B0525E /* params.h */,
+				75E2E8B927FCAC0800B0525E /* params.hpp */,
 			);
 			name = gui;
 			path = ../../src/gui;

--- a/xcode/TrominoCli/TrominoCli.xcodeproj/project.pbxproj
+++ b/xcode/TrominoCli/TrominoCli.xcodeproj/project.pbxproj
@@ -28,20 +28,20 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		75002AB527A5D71A00CBB593 /* cli_models.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = cli_models.h; sourceTree = "<group>"; };
-		75002AB727A5EB8C00CBB593 /* cli_options.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = cli_options.h; sourceTree = "<group>"; };
+		75002AB527A5D71A00CBB593 /* cli_models.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.hpp; path = cli_models.hpp; sourceTree = "<group>"; };
+		75002AB727A5EB8C00CBB593 /* cli_options.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = cli_options.hpp; sourceTree = "<group>"; };
 		75002AB827A5EB8C00CBB593 /* cli_options.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = cli_options.cpp; sourceTree = "<group>"; };
-		7503E76F26C88C910018B1F2 /* trmn_graph.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = trmn_graph.h; sourceTree = "<group>"; };
+		7503E76F26C88C910018B1F2 /* trmn_graph.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = trmn_graph.hpp; sourceTree = "<group>"; };
 		7503E77026C88C910018B1F2 /* trmn_graph_vt.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = trmn_graph_vt.cpp; sourceTree = "<group>"; };
 		7503E77226C88C910018B1F2 /* init.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = init.cpp; sourceTree = "<group>"; };
-		7503E77426C88C910018B1F2 /* init.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = init.h; sourceTree = "<group>"; };
+		7503E77426C88C910018B1F2 /* init.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = init.hpp; sourceTree = "<group>"; };
 		7503E77826C88C910018B1F2 /* main.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = main.cpp; sourceTree = "<group>"; };
-		7503E77926C88C910018B1F2 /* trmn_graph_vt.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = trmn_graph_vt.h; sourceTree = "<group>"; };
+		7503E77926C88C910018B1F2 /* trmn_graph_vt.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = trmn_graph_vt.hpp; sourceTree = "<group>"; };
 		755F9D232811CB3B004C54E0 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		758EF489284E50FA0069A198 /* libtromino.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libtromino.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		758EF48B284E50FA0069A198 /* libtromino-validation.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = "libtromino-validation.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		7594DBDB26C4822400CF433E /* tromino */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = tromino; sourceTree = BUILT_PRODUCTS_DIR; };
-		75E2E8BC27FCB7CF00B0525E /* params.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = params.h; sourceTree = "<group>"; };
+		75E2E8BC27FCB7CF00B0525E /* params.hpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.hpp; path = params.hpp; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -60,16 +60,16 @@
 		7503E76E26C88C910018B1F2 /* cli */ = {
 			isa = PBXGroup;
 			children = (
-				75E2E8BC27FCB7CF00B0525E /* params.h */,
+				75E2E8BC27FCB7CF00B0525E /* params.hpp */,
 				75002AB827A5EB8C00CBB593 /* cli_options.cpp */,
-				75002AB727A5EB8C00CBB593 /* cli_options.h */,
-				7503E76F26C88C910018B1F2 /* trmn_graph.h */,
+				75002AB727A5EB8C00CBB593 /* cli_options.hpp */,
+				7503E76F26C88C910018B1F2 /* trmn_graph.hpp */,
 				7503E77026C88C910018B1F2 /* trmn_graph_vt.cpp */,
 				7503E77226C88C910018B1F2 /* init.cpp */,
-				7503E77426C88C910018B1F2 /* init.h */,
+				7503E77426C88C910018B1F2 /* init.hpp */,
 				7503E77826C88C910018B1F2 /* main.cpp */,
-				7503E77926C88C910018B1F2 /* trmn_graph_vt.h */,
-				75002AB527A5D71A00CBB593 /* cli_models.h */,
+				7503E77926C88C910018B1F2 /* trmn_graph_vt.hpp */,
+				75002AB527A5D71A00CBB593 /* cli_models.hpp */,
 			);
 			name = cli;
 			path = ../../src/cli;

--- a/xcode/UnitTests/UnitTests.xcodeproj/project.pbxproj
+++ b/xcode/UnitTests/UnitTests.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		7503E7D126C894EC0018B1F2 /* tromino_2x2_unittest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = tromino_2x2_unittest.cpp; sourceTree = "<group>"; };
 		7525762C26F7634500BB3EB3 /* tromino_4x4_unittest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tromino_4x4_unittest.cpp; sourceTree = "<group>"; };
 		7525762F26F76BB400BB3EB3 /* unittest_helper.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = unittest_helper.cpp; sourceTree = "<group>"; };
-		7525763026F76BB400BB3EB3 /* unittest_helper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = unittest_helper.h; sourceTree = "<group>"; };
+		7525763026F76BB400BB3EB3 /* unittest_helper.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.hpp; path = unittest_helper.hpp; sourceTree = "<group>"; };
 		7525763426F77D4700BB3EB3 /* tromino_64x64_unittest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = tromino_64x64_unittest.cpp; sourceTree = "<group>"; };
 		755F9D212811CA4B004C54E0 /* Config.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Config.xcconfig; sourceTree = "<group>"; };
 		758EF493284E53120069A198 /* libtromino.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; path = libtromino.a; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -91,7 +91,7 @@
 				7503E7D126C894EC0018B1F2 /* tromino_2x2_unittest.cpp */,
 				7525762C26F7634500BB3EB3 /* tromino_4x4_unittest.cpp */,
 				7525762F26F76BB400BB3EB3 /* unittest_helper.cpp */,
-				7525763026F76BB400BB3EB3 /* unittest_helper.h */,
+				7525763026F76BB400BB3EB3 /* unittest_helper.hpp */,
 				7525763426F77D4700BB3EB3 /* tromino_64x64_unittest.cpp */,
 			);
 			name = libtromino;


### PR DESCRIPTION
Change C++ header file extensions to .hpp for simpler static analysis tool setup.