### PR TITLE
build!: Drop build for 32-bit Windows

### DIFF
--- a/src/cli/cli_models.hpp
+++ b/src/cli/cli_models.hpp
@@ -9,21 +9,21 @@
 
 namespace tromino::cli {
 
-#ifdef _WINDOWS
+#ifdef _WIN64
 enum class emulation_mode_type {
     vt100 = 0,
     wch = 1,
 };
-#endif // _WINDOWS
+#endif // _WIN64
 
 struct options {
     int order{};
     int x{};
     int y{};
-#ifdef _WINDOWS
+#ifdef _WIN64
     emulation_mode_type emulation_mode{};
     bool use_wch{};
-#endif // _WINDOWS
+#endif // _WIN64
 };
 
 } // namespace tromino::cli

--- a/src/cli/cli_options.cpp
+++ b/src/cli/cli_options.cpp
@@ -16,7 +16,7 @@ void print_usage(std::ostream& os) noexcept {
     // clang-format off
     os <<
         "Usage: tromino <order> <x> <y>"
-#ifdef _WINDOWS
+#ifdef _WIN64
         " [options]\n"
         "\n"
         "Options:\n"
@@ -24,7 +24,7 @@ void print_usage(std::ostream& os) noexcept {
         "\n"
 #else
         "\n\n"
-#endif // _WINDOWS
+#endif // _WIN64
         "Copyright (c) 2021-2023 Omar Boukli-Hacene. All rights reserved.\n"
         << std::endl;
     // clang-format on
@@ -40,7 +40,7 @@ bool read_options(
     if (argc < params::REQUIRED_ARG_COUNT) {
         error = "Incorrect argument count."s;
     } else {
-#ifdef _WINDOWS
+#ifdef _WIN64
         options.use_wch = argc > params::REQUIRED_ARG_COUNT
             && std::string(argv[params::USE_WCH_ARG_IDX]) == "--use-wch"s;
 
@@ -49,7 +49,7 @@ bool read_options(
             ? emulation_mode_type::wch
             : emulation_mode_type::vt100;
         // clang-format on
-#endif // _WINDOWS
+#endif // _WIN64
 
         options.order = std::stoi(argv[params::ORDER_ARG_IDX]);
         options.x = std::stoi(argv[params::MARKX_ARG_IDX]);

--- a/src/cli/init.cpp
+++ b/src/cli/init.cpp
@@ -12,9 +12,9 @@
 #include "trmn_graph.hpp"
 #include "trmn_graph_vt.hpp"
 
-#ifdef _WINDOWS
+#ifdef _WIN64
 #include "trmn_graph_windows.hpp"
-#endif // _WINDOWS
+#endif // _WIN64
 
 namespace tromino::cli::app {
 
@@ -32,7 +32,7 @@ void init(int const order, int const x, int const y) noexcept {
     tromino::cli::vt::use_vt(tromino_board, std::cout);
 }
 
-#ifdef _WINDOWS
+#ifdef _WIN64
 void init(
     int const order, int const x, int const y,
     emulation_mode_type const emulation_mode) noexcept {
@@ -53,6 +53,6 @@ void init(
 
     tromino::cli::vt::use_vt(tromino_board, std::cout);
 }
-#endif // _WINDOWS
+#endif // _WIN64
 
 } // namespace tromino::cli::app

--- a/src/cli/init.hpp
+++ b/src/cli/init.hpp
@@ -13,11 +13,11 @@ namespace tromino::cli::app {
 
 void init(int const order, int const x, int const y) noexcept;
 
-#ifdef _WINDOWS
+#ifdef _WIN64
 void init(
     int const order, int const x, int const y,
     emulation_mode_type const emulation_mode) noexcept;
-#endif // _WINDOWS
+#endif // _WIN64
 
 } // namespace tromino::cli::app
 

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -25,12 +25,12 @@ int main(int const argc, char const* const argv[]) noexcept {
         std::cerr << error << std::endl;
         tromino::cli::print_usage(std::cout);
     } else {
-#ifdef _WINDOWS
+#ifdef _WIN64
         tromino::cli::app::init(
             options.order, options.x, options.y, options.emulation_mode);
 #else
         tromino::cli::app::init(options.order, options.x, options.y);
-#endif // _WINDOWS
+#endif // _WIN64
 
         exit_status = EXIT_SUCCESS;
     }

--- a/src/cli/params.hpp
+++ b/src/cli/params.hpp
@@ -15,9 +15,9 @@ constexpr int const ORDER_ARG_IDX{1};
 constexpr int const MARKX_ARG_IDX{2};
 constexpr int const MARKY_ARG_IDX{3};
 
-#ifdef _WINDOWS
+#ifdef _WIN64
 constexpr int const USE_WCH_ARG_IDX{4};
-#endif
+#endif // _WIN64
 
 } // namespace tromino::cli::params
 

--- a/src/cli/trmn_graph.hpp
+++ b/src/cli/trmn_graph.hpp
@@ -7,10 +7,10 @@
 #ifndef CLI_TRMN_GRAPH_HPP
 #define CLI_TRMN_GRAPH_HPP
 
-#ifdef _WINDOWS
+#ifdef _WIN64
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
-#endif // _WINDOWS
+#endif // _WIN64
 
 #include <array>
 #include <cassert>
@@ -37,9 +37,9 @@ struct board_t {
 struct graph_state_t {
     std::ostream& os;
     board_t& board;
-#ifdef _WINDOWS
+#ifdef _WIN64
     ::HANDLE hOutput{};
-#endif // _WINDOWS
+#endif // _WIN64
 };
 
 template <typename T>

--- a/src/cli/trmn_graph_vt.cpp
+++ b/src/cli/trmn_graph_vt.cpp
@@ -66,12 +66,12 @@ void add_tromino(
         }
     }
 
-#ifdef _WINDOWS
+#ifdef _WIN64
     ::DWORD dwMode{};
     ::GetConsoleMode(graph_state->hOutput, &dwMode);
     dwMode |= ENABLE_PROCESSED_OUTPUT | ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     ::SetConsoleMode(graph_state->hOutput, dwMode);
-#endif // _WINDOWS
+#endif // _WIN64
 
     draw_at(order, order, '\0', os);
 
@@ -81,7 +81,7 @@ void add_tromino(
 }
 
 void use_vt(board_t& tromino_board, std::ostream& os) noexcept {
-#ifdef _WINDOWS
+#ifdef _WIN64
     ::HANDLE const hStdout{::GetStdHandle(STD_OUTPUT_HANDLE)};
 
     ::DWORD dwConsoleOriginalMode{};
@@ -96,7 +96,7 @@ void use_vt(board_t& tromino_board, std::ostream& os) noexcept {
             = dwConsoleOriginalMode | dwConsoleModeRequiredFlags;
         ::SetConsoleMode(hStdout, dwConsoleModifiedMode);
     }
-#endif // _WINDOWS
+#endif // _WIN64
 
     init_board(tromino_board);
 
@@ -194,10 +194,10 @@ void use_vt(board_t& tromino_board, std::ostream& os) noexcept {
 
     os << std::flush;
 
-#ifdef _WINDOWS
+#ifdef _WIN64
     assert(dwConsoleOriginalMode != 0);
     ::SetConsoleMode(hStdout, dwConsoleOriginalMode);
-#endif // _WINDOWS
+#endif // _WIN64
 }
 
 } // namespace tromino::cli::vt

--- a/src/cli/trmn_graph_vt.hpp
+++ b/src/cli/trmn_graph_vt.hpp
@@ -7,10 +7,10 @@
 #ifndef CLI_TRMN_GRAPH_VT_HPP
 #define CLI_TRMN_GRAPH_VT_HPP
 
-#ifdef _WINDOWS
+#ifdef _WIN64
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
-#endif // _WINDOWS
+#endif // _WIN64
 
 #include <algorithm>
 #include <iostream>

--- a/src/gui/params.hpp
+++ b/src/gui/params.hpp
@@ -17,7 +17,7 @@ constexpr int const REQUIRED_ARG_COUNT{4};
 constexpr int const MAX_SUPPORTED_ORDER{512};
 #elif __linux__
 constexpr int const MAX_SUPPORTED_ORDER{32};
-#elif _WINDOWS
+#elif _WIN64
 constexpr int const MAX_SUPPORTED_ORDER{64};
 #else
 constexpr int const MAX_SUPPORTED_ORDER{32};


### PR DESCRIPTION
BREAKING CHANGE: Only building for 64-bit Windows is supported. Windows CLI app assumes Windows 10 version 1511 (November Update, build 10586), Windows Server 2016, or higher